### PR TITLE
Add ntfy.sh push notifications to Claude Code hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Files are stowed relative to `$HOME`, so `git/.gitconfig` becomes `~/.gitconfig`
 ## macOS shell scripting gotchas
 
 - `sed -i '' -e 'expr' file` exits 2 with "can't read : No such file" on macOS even when the edit succeeds — use `sed -i''` (no space) instead
+- `cmd < file 2>/dev/null` does NOT suppress bash's "no such file" error for the redirect — use `cat file 2>/dev/null | cmd` instead (add `# shellcheck disable=SC2002`)
 - Check `shell/.local/lib/aliases.sh` for alias conflicts before naming new scripts in `~/.local/bin/`
 - If a newly stowed command isn't found, ask the user to reload their shell (`exec zsh`) — don't work around it by using the full `~/.local/bin/` path
 

--- a/shell/.claude/hooks/on-elicitation
+++ b/shell/.claude/hooks/on-elicitation
@@ -18,6 +18,6 @@ terminal-notifier \
   -sound Purr \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify "Claude Code - $dir_context" "Has a question for you"
+ntfy-notify --away-only "Claude Code - $dir_context" "Has a question for you"
 
 [ -n "$TMUX" ] && tmux rename-window "⏸ $(basename "${cwd:-$PWD}")"

--- a/shell/.claude/hooks/on-elicitation
+++ b/shell/.claude/hooks/on-elicitation
@@ -18,6 +18,6 @@ terminal-notifier \
   -sound Purr \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify --away-only "Claude Code - $dir_context" "Has a question for you"
+ntfy-notify --away-only --topic claude "Claude Code - $dir_context" "Has a question for you"
 
 [ -n "$TMUX" ] && tmux rename-window "⏸ $(basename "${cwd:-$PWD}")"

--- a/shell/.claude/hooks/on-elicitation
+++ b/shell/.claude/hooks/on-elicitation
@@ -18,4 +18,6 @@ terminal-notifier \
   -sound Purr \
   -contentImage "$HOME/.claude/icons/claude.png"
 
+ntfy-notify "Claude Code - $dir_context" "Has a question for you"
+
 [ -n "$TMUX" ] && tmux rename-window "⏸ $(basename "${cwd:-$PWD}")"

--- a/shell/.claude/hooks/on-notification
+++ b/shell/.claude/hooks/on-notification
@@ -20,4 +20,4 @@ terminal-notifier \
   -sound "$sound" \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify --away-only --topic claude "Claude Code - $dir_context" "$message"
+ntfy-notify --away-only --topic claude --tags robot "Claude Code - $dir_context" "$message"

--- a/shell/.claude/hooks/on-notification
+++ b/shell/.claude/hooks/on-notification
@@ -20,4 +20,4 @@ terminal-notifier \
   -sound "$sound" \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify "Claude Code - $dir_context" "$message"
+ntfy-notify --away-only "Claude Code - $dir_context" "$message"

--- a/shell/.claude/hooks/on-notification
+++ b/shell/.claude/hooks/on-notification
@@ -20,4 +20,4 @@ terminal-notifier \
   -sound "$sound" \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify --away-only "Claude Code - $dir_context" "$message"
+ntfy-notify --away-only --topic claude "Claude Code - $dir_context" "$message"

--- a/shell/.claude/hooks/on-notification
+++ b/shell/.claude/hooks/on-notification
@@ -19,3 +19,5 @@ terminal-notifier \
   -message "$message" \
   -sound "$sound" \
   -contentImage "$HOME/.claude/icons/claude.png"
+
+ntfy-notify "Claude Code - $dir_context" "$message"

--- a/shell/.claude/hooks/on-stop
+++ b/shell/.claude/hooks/on-stop
@@ -18,7 +18,7 @@ terminal-notifier \
   -sound Glass \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify "Claude Code - $dir_context" "Done"
+ntfy-notify --away-only "Claude Code - $dir_context" "Done"
 
 # Clear ⏺ from the current tmux window only
 if [ -n "$TMUX" ]; then

--- a/shell/.claude/hooks/on-stop
+++ b/shell/.claude/hooks/on-stop
@@ -18,7 +18,7 @@ terminal-notifier \
   -sound Glass \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify --away-only --topic claude "Claude Code - $dir_context" "Done"
+ntfy-notify --away-only --topic claude --tags robot "Claude Code - $dir_context" "Done"
 
 # Clear ⏺ from the current tmux window only
 if [ -n "$TMUX" ]; then

--- a/shell/.claude/hooks/on-stop
+++ b/shell/.claude/hooks/on-stop
@@ -18,6 +18,8 @@ terminal-notifier \
   -sound Glass \
   -contentImage "$HOME/.claude/icons/claude.png"
 
+ntfy-notify "Claude Code - $dir_context" "Done"
+
 # Clear ⏺ from the current tmux window only
 if [ -n "$TMUX" ]; then
   current_name=$(tmux display-message -p '#{window_name}' 2>/dev/null)

--- a/shell/.claude/hooks/on-stop
+++ b/shell/.claude/hooks/on-stop
@@ -18,7 +18,7 @@ terminal-notifier \
   -sound Glass \
   -contentImage "$HOME/.claude/icons/claude.png"
 
-ntfy-notify --away-only "Claude Code - $dir_context" "Done"
+ntfy-notify --away-only --topic claude "Claude Code - $dir_context" "Done"
 
 # Clear ⏺ from the current tmux window only
 if [ -n "$TMUX" ]; then

--- a/shell/.claude/settings.json
+++ b/shell/.claude/settings.json
@@ -26,6 +26,7 @@
       "Bash(mkdir:*)",
       "Bash(sips:*)",
       "Bash(terminal-notifier:*)",
+      "Bash(ntfy-notify:*)",
       "Bash(echo:*)",
       "Bash(jq:*)",
       "Bash(stow:*)",

--- a/shell/.config/ntfy/topic.example
+++ b/shell/.config/ntfy/topic.example
@@ -1,0 +1,1 @@
+your-secret-ntfy-topic

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -32,7 +32,8 @@ done
 title="${1:?title required}"
 message="${2:?message required}"
 
-topic="${topic_arg:-${NTFY_TOPIC:-$(tr -d '[:space:]' < ~/.config/ntfy/topic 2>/dev/null)}}"
+# shellcheck disable=SC2002
+topic="${topic_arg:-${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}}"
 [ -z "$topic" ] && exit 0
 
 if [ "$away_only" = "1" ]; then

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Send a push notification via ntfy.sh (or self-hosted ntfy server).
-# Usage: ntfy-notify <title> <message>
+# Usage: ntfy-notify [--away-only] <title> <message>
+#
+# Options:
+#   --away-only   Only send if screensaver is running or display is sleeping
 #
 # Config (pick one):
 #   - Set NTFY_TOPIC env var to your topic name
@@ -12,20 +15,27 @@
 # To set up: cp ~/.config/ntfy/topic.example ~/.config/ntfy/topic
 # and replace the placeholder with your ntfy topic name.
 
+away_only=0
+if [ "$1" = "--away-only" ]; then
+  away_only=1
+  shift
+fi
+
 title="${1:?title required}"
 message="${2:?message required}"
 
 topic="${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}"
 [ -z "$topic" ] && exit 0
 
-# Only fire when away from desk: screensaver running or display sleeping
-_is_away() {
-  pgrep -x ScreenSaverEngine > /dev/null 2>&1 && return 0
-  local power_state
-  power_state=$(ioreg -n IODisplayWrangler -r 2>/dev/null | grep '"CurrentPowerState"' | awk -F= '{print $2}' | tr -d ' ')
-  [ -n "$power_state" ] && [ "$power_state" != "4" ]
-}
-_is_away || exit 0
+if [ "$away_only" = "1" ]; then
+  _is_away() {
+    pgrep -x ScreenSaverEngine > /dev/null 2>&1 && return 0
+    local power_state
+    power_state=$(ioreg -n IODisplayWrangler -r 2>/dev/null | grep '"CurrentPowerState"' | awk -F= '{print $2}' | tr -d ' ')
+    [ -n "$power_state" ] && [ "$power_state" != "4" ]
+  }
+  _is_away || exit 0
+fi
 
 url="${NTFY_URL:-https://ntfy.sh}/$topic"
 

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -39,7 +39,13 @@ fi
 
 url="${NTFY_URL:-https://ntfy.sh}/$topic"
 
+auth_args=()
+if [ -n "$NTFY_TOKEN" ]; then
+  auth_args=(-H "Authorization: Bearer $NTFY_TOKEN")
+fi
+
 curl -s -o /dev/null \
+  "${auth_args[@]}" \
   -H "Title: $title" \
   -d "$message" \
   "$url" &

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -44,8 +44,11 @@ if [ -n "$NTFY_TOKEN" ]; then
   auth_args=(-H "Authorization: Bearer $NTFY_TOKEN")
 fi
 
+title="${title//$'\r'/}"
+title="${title//$'\n'/}"
+
 curl -s -o /dev/null \
   "${auth_args[@]}" \
   -H "Title: $title" \
-  -d "$message" \
+  --data-raw "$message" \
   "$url" &

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -5,7 +5,7 @@
 # Options:
 #   --away-only        Only send if screensaver is running or display is sleeping
 #   --topic <topic>    Override the ntfy topic (overrides env var and config file)
-#   --tags <tag1,...>  Comma-separated list of ntfy tags (emoji shortcuts supported)
+#   --tag|--tags <tag1,...>  Comma-separated list of ntfy tags (emoji shortcuts supported)
 #   --debug            Print resolved config and curl command without sending
 #
 # Config:
@@ -26,7 +26,7 @@ while true; do
     --away-only) away_only=1; shift ;;
     --debug) debug=1; shift ;;
     --topic) topic_arg="${2:?topic value required}"; shift 2 ;;
-    --tags) tags_arg="$2"; shift 2 ;;
+    --tag|--tags) tags_arg="$2"; shift 2 ;;
     *) break ;;
   esac
 done

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Send a push notification via ntfy.sh (or self-hosted ntfy server).
-# Usage: ntfy-notify [--away-only] <title> <message>
+# Usage: ntfy-notify [--away-only] [--topic <topic>] <title> <message>
 #
 # Options:
-#   --away-only   Only send if screensaver is running or display is sleeping
+#   --away-only      Only send if screensaver is running or display is sleeping
+#   --topic <topic>  Override the ntfy topic (overrides env var and config file)
 #
 # Config (pick one):
 #   - Set NTFY_TOPIC env var to your topic name
@@ -16,15 +17,19 @@
 # and replace the placeholder with your ntfy topic name.
 
 away_only=0
-if [ "$1" = "--away-only" ]; then
-  away_only=1
-  shift
-fi
+topic_arg=""
+while true; do
+  case "$1" in
+    --away-only) away_only=1; shift ;;
+    --topic) topic_arg="${2:?topic value required}"; shift 2 ;;
+    *) break ;;
+  esac
+done
 
 title="${1:?title required}"
 message="${2:?message required}"
 
-topic="${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}"
+topic="${topic_arg:-${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}}"
 [ -z "$topic" ] && exit 0
 
 if [ "$away_only" = "1" ]; then

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Send a push notification via ntfy.sh (or self-hosted ntfy server).
-# Usage: ntfy-notify [--away-only] [--topic <topic>] <title> <message>
+# Usage: ntfy-notify [--away-only] [--topic <topic>] [--tags <tag1,tag2>] <title> <message>
 #
 # Options:
-#   --away-only      Only send if screensaver is running or display is sleeping
-#   --topic <topic>  Override the ntfy topic (overrides env var and config file)
+#   --away-only        Only send if screensaver is running or display is sleeping
+#   --topic <topic>    Override the ntfy topic (overrides env var and config file)
+#   --tags <tag1,...>  Comma-separated list of ntfy tags (emoji shortcuts supported)
 #
 # Config (pick one):
 #   - Set NTFY_TOPIC env var to your topic name
@@ -18,10 +19,12 @@
 
 away_only=0
 topic_arg=""
+tags_arg=""
 while true; do
   case "$1" in
     --away-only) away_only=1; shift ;;
     --topic) topic_arg="${2:?topic value required}"; shift 2 ;;
+    --tags) tags_arg="$2"; shift 2 ;;
     *) break ;;
   esac
 done
@@ -29,7 +32,7 @@ done
 title="${1:?title required}"
 message="${2:?message required}"
 
-topic="${topic_arg:-${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}}"
+topic="${topic_arg:-${NTFY_TOPIC:-$(tr -d '[:space:]' < ~/.config/ntfy/topic 2>/dev/null)}}"
 [ -z "$topic" ] && exit 0
 
 if [ "$away_only" = "1" ]; then
@@ -49,11 +52,17 @@ if [ -n "$NTFY_TOKEN" ]; then
   auth_args=(-H "Authorization: Bearer $NTFY_TOKEN")
 fi
 
+tags_header=()
+if [ -n "$tags_arg" ]; then
+  tags_header=(-H "Tags: $tags_arg")
+fi
+
 title="${title//$'\r'/}"
 title="${title//$'\n'/}"
 
 curl -s -o /dev/null \
   "${auth_args[@]}" \
+  "${tags_header[@]}" \
   -H "Title: $title" \
   --data-raw "$message" \
   "$url" &

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Send a push notification via ntfy.sh (or self-hosted ntfy server).
+# Usage: ntfy-notify <title> <message>
+#
+# Config (pick one):
+#   - Set NTFY_TOPIC env var to your topic name
+#   - Write your topic name to ~/.config/ntfy/topic
+#
+# Optional:
+#   - Set NTFY_URL for a self-hosted server (default: https://ntfy.sh)
+#
+# To set up: cp ~/.config/ntfy/topic.example ~/.config/ntfy/topic
+# and replace the placeholder with your ntfy topic name.
+
+title="${1:?title required}"
+message="${2:?message required}"
+
+topic="${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}"
+[ -z "$topic" ] && exit 0
+
+url="${NTFY_URL:-https://ntfy.sh}/$topic"
+
+curl -s -o /dev/null \
+  -H "Title: $title" \
+  -d "$message" \
+  "$url" &

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -6,7 +6,7 @@
 #   --away-only        Only send if screensaver is running or display is sleeping
 #   --topic <topic>    Override the ntfy topic (overrides env var and config file)
 #   --tags <tag1,...>  Comma-separated list of ntfy tags (emoji shortcuts supported)
-#   --debug            Print the curl command instead of running it
+#   --debug            Print resolved config and curl command without sending
 #
 # Config:
 #   - Write your topic name to ~/.config/ntfy/topic
@@ -36,7 +36,10 @@ message="${2:?message required}"
 
 # shellcheck disable=SC2002
 topic="${topic_arg:-${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}}"
-[ -z "$topic" ] && exit 0
+if [ -z "$topic" ]; then
+  [ "$debug" = "1" ] && echo "--> no topic configured, exiting"
+  exit 0
+fi
 
 if [ "$away_only" = "1" ]; then
   _is_away() {
@@ -45,7 +48,10 @@ if [ "$away_only" = "1" ]; then
     power_state=$(ioreg -n IODisplayWrangler -r 2>/dev/null | grep '"CurrentPowerState"' | awk -F= '{print $2}' | tr -d ' ')
     [ -n "$power_state" ] && [ "$power_state" != "4" ]
   }
-  _is_away || exit 0
+  if ! _is_away; then
+    [ "$debug" = "1" ] && echo "--> screen active, skipping (--away-only)"
+    exit 0
+  fi
 fi
 
 url="${NTFY_URL:-https://ntfy.sh}/$topic"
@@ -64,6 +70,12 @@ title="${title//$'\r'/}"
 title="${title//$'\n'/}"
 
 if [ "$debug" = "1" ]; then
+  echo "--> topic:   $topic"
+  echo "--> url:     $url"
+  echo "--> title:   $title"
+  echo "--> message: $message"
+  [ -n "$tags_arg" ] && echo "--> tags:    $tags_arg"
+  [ -n "$NTFY_TOKEN" ] && echo "--> auth:    Bearer token set"
   echo "curl ${auth_args[*]} ${tags_header[*]} -H 'Title: $title' --data-raw '$message' '$url'"
 else
   curl -s -o /dev/null \

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -8,8 +8,7 @@
 #   --tags <tag1,...>  Comma-separated list of ntfy tags (emoji shortcuts supported)
 #   --debug            Print the curl command instead of running it
 #
-# Config (pick one):
-#   - Set NTFY_TOPIC env var to your topic name
+# Config:
 #   - Write your topic name to ~/.config/ntfy/topic
 #
 # Optional:

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -18,6 +18,15 @@ message="${2:?message required}"
 topic="${NTFY_TOPIC:-$(cat ~/.config/ntfy/topic 2>/dev/null | tr -d '[:space:]')}"
 [ -z "$topic" ] && exit 0
 
+# Only fire when away from desk: screensaver running or display sleeping
+_is_away() {
+  pgrep -x ScreenSaverEngine > /dev/null 2>&1 && return 0
+  local power_state
+  power_state=$(ioreg -n IODisplayWrangler -r 2>/dev/null | grep '"CurrentPowerState"' | awk -F= '{print $2}' | tr -d ' ')
+  [ -n "$power_state" ] && [ "$power_state" != "4" ]
+}
+_is_away || exit 0
+
 url="${NTFY_URL:-https://ntfy.sh}/$topic"
 
 curl -s -o /dev/null \

--- a/shell/.local/bin/ntfy-notify
+++ b/shell/.local/bin/ntfy-notify
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Send a push notification via ntfy.sh (or self-hosted ntfy server).
-# Usage: ntfy-notify [--away-only] [--topic <topic>] [--tags <tag1,tag2>] <title> <message>
+# Usage: ntfy-notify [--away-only] [--topic <topic>] [--tags <tag1,tag2>] [--debug] <title> <message>
 #
 # Options:
 #   --away-only        Only send if screensaver is running or display is sleeping
 #   --topic <topic>    Override the ntfy topic (overrides env var and config file)
 #   --tags <tag1,...>  Comma-separated list of ntfy tags (emoji shortcuts supported)
+#   --debug            Print the curl command instead of running it
 #
 # Config (pick one):
 #   - Set NTFY_TOPIC env var to your topic name
@@ -18,11 +19,13 @@
 # and replace the placeholder with your ntfy topic name.
 
 away_only=0
+debug=0
 topic_arg=""
 tags_arg=""
 while true; do
   case "$1" in
     --away-only) away_only=1; shift ;;
+    --debug) debug=1; shift ;;
     --topic) topic_arg="${2:?topic value required}"; shift 2 ;;
     --tags) tags_arg="$2"; shift 2 ;;
     *) break ;;
@@ -61,9 +64,13 @@ fi
 title="${title//$'\r'/}"
 title="${title//$'\n'/}"
 
-curl -s -o /dev/null \
-  "${auth_args[@]}" \
-  "${tags_header[@]}" \
-  -H "Title: $title" \
-  --data-raw "$message" \
-  "$url" &
+if [ "$debug" = "1" ]; then
+  echo "curl ${auth_args[*]} ${tags_header[*]} -H 'Title: $title' --data-raw '$message' '$url'"
+else
+  curl -s -o /dev/null \
+    "${auth_args[@]}" \
+    "${tags_header[@]}" \
+    -H "Title: $title" \
+    --data-raw "$message" \
+    "$url" &
+fi


### PR DESCRIPTION
Adds a shared ntfy-notify script that sends push notifications via ntfy.sh
(or a self-hosted server), called from on-stop, on-elicitation, and
on-notification hooks alongside the existing terminal-notifier calls. This
enables remote/mobile notifications when away from the desk.

Config: copy ~/.config/ntfy/topic.example to ~/.config/ntfy/topic and set
your ntfy topic, or export NTFY_TOPIC. Silently no-ops if not configured.

https://claude.ai/code/session_015EdSwe4Lnxk57qLTU2LTFC