### PR TITLE
docs: add scope, rollback, test-gate, and fix-quality guardrails to Claude instructions

### DIFF
--- a/shell/.claude/CLAUDE.md
+++ b/shell/.claude/CLAUDE.md
@@ -54,6 +54,27 @@ Include a prominent model suggestion, e.g.:
 - Do NOT write multiple tests at once or implement ahead of the current test
 - Never use "should" at the beginning of test descriptions. E.g. BAD it('should return wibble'). GOOD it('returns wibble')
 
+## Fixes and debugging
+
+When fixing a failing test or build error, always explain the root cause before
+proposing a fix. Do NOT apply workarounds that suppress symptoms without explicit
+user approval, including:
+- Increasing memory or timeout limits
+- Adding @ts-ignore, eslint-disable, or @SuppressWarnings
+- Commenting out or skipping failing assertions or tests
+- Catching and swallowing exceptions
+
+If the correct fix is unclear, say so and ask rather than patching around the problem.
+
+## Context management
+
+When a session grows long or the task scope shifts significantly, suggest running
+/compact or starting a fresh session. Long accumulating context degrades output
+quality — prefer shorter focused sessions over one long running one.
+
+Do not load large files or entire codebases into context unless directly needed for
+the current step. Include relevant modules only.
+
 ## Tmux/Neovim
 - Neovim runs in the `dev` tmux session. The window is named after the project directory.
 - The current project's window name matches the basename of the working directory. Use that window, not just any nvim pane.

--- a/shell/.claude/docs/task-workflow.md
+++ b/shell/.claude/docs/task-workflow.md
@@ -21,6 +21,10 @@ the next action:
    - **Always end plans with a bold recommended model**, e.g.:
      **> Recommended model for implementation: Sonnet (Opt+P)**
    - Get user approval before implementation
+   - Plans must include an explicit **Out of scope** section listing files, APIs, and
+     behaviours that must not be changed.
+   - Plans must include a **Rollback plan**: how to revert the change if needed. This
+     should inform design choices — prefer reversible changes.
    - If a Linear ticket exists, update its description with the accepted plan: preserve any
      existing description, add a horizontal rule (`---`), and append the plan below it
    - Run `/notes` after plan is accepted
@@ -32,6 +36,14 @@ the next action:
    - Make changes incrementally
    - Run linter/formatter before committing
    - Run tests to verify functionality
+   - **Never accept "tests pass" on trust** — always verify actual runner output. If
+     tests are skipped, pending, or erroring in setup, treat this as a failing gate.
+   - Do not proceed to the next step if any gate has been bypassed (e.g. --force,
+     skipped tests, or @ignore annotations added during this session).
+   - When starting each plan step, explicitly list the files in scope: "Implement only
+     step N. Files allowed: [list]. Do not modify anything outside this list."
+   - If a change requires touching out-of-scope files, stop and flag it rather than
+     proceeding.
    - Commit work with clear messages
    - Run `/notes` after commits
 


### PR DESCRIPTION
Add five improvements to CLAUDE.md and task-workflow.md based on patterns
documented as common agentic coding failure modes (Böckeler, Osmani, Rana):

- Planning step now requires explicit out-of-scope and rollback sections
- Development step gains a false-green test guard and per-step file scope constraint
- New "Fixes and debugging" section prohibits suppression workarounds without approval
- New "Context management" section encourages /compact and focused sessions

https://claude.ai/code/session_01LDAZCroi6omZ2ko2QcBKXT